### PR TITLE
Add stable one-sync reortho

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ Follow the download options from the Git repository main page.  Then navigate to
 * [`RunKappaPlot`](#new-test-driver): a unified, streamlined test engine that avoids redundant runs of skeleton-muscle combinations, simplifies syntax via an options struct, improves display of figure outputs, allows for toggling how and whether figures are saved (.eps, .pdf, and .fig formats allowed), and auto-generates a timestamped TeX report, which can be easily compiled and shared with collaborators.
 * A new class of test matrices called `piled` matrices: they are similar to `glued`, but can more easily highlight edge-case behavior for some methods.
 * `bcgs_a`, `bcgs_iro_a`, and `bcgs_iro_a_3s` can now accept a [`multiIO`](#multiio) struct for the `musc` argument.  Note that `bcgs_iro_a_2s` and `bcgs_iro_a_1s` already only accept one `musc`.
+* New Pythagorean routines `bcgs_iro_p_1s`, `bcgs_iro_p_2s`, and `bcgs_iro_p_1s_2s` that attain 1 sync, 2 sync, and ~1.5 syncs per iteration with O(eps) loss of orthogonality.
 
 ## `multiIO`
 
-A `multiIO` struct should have the follow form (which can be mapped from JSON to a struct via the `jsonencode` command):
+A `multiIO` struct should have the following form (which can be mapped from JSON to a struct via the `jsonencode` command):
 
 ```json
 {
@@ -234,6 +235,7 @@ Several works are associated with this repository:
 * [Carson, et al. 2022](https://doi.org/10.1016/j.laa.2021.12.017): Carson, E., Lund, K., Rozložník, M., and Thomas, S. Block Gram-Schmidt algorithms and their stability properties, Linear Algebra and its Applications. Vol. 638, 20, pp 150-195, 2022. DOI: 10.1016/j.laa.2021.12.017.
 * [Carson, et al. 2024 A](https://doi.org/10.48550/arXiv.2405.01298): Carson, E., Lund, K., Ma, Y., and Oktay, E.  Reorthogonalized Pythagorean variants of block classical Gram-Schmidt. arXiv:2405.01298, 2024. DOI: 10.48550/arXiv.2405.01298.
 * [Carson, et al. 2024 B](https://doi.org/10.48550/arXiv.2408.10109): Carson, E., Lund, K., Ma, Y., and Oktay, E.  On the loss of orthogonality in low-synchronization variants of reorthogonalized block classical Gram-Schmidt. arXiv:2408.10109, 2024. DOI: 10.48550/arXiv.2408.10109.
+* [Carson & Ma 2024](https://doi.org/10.48550/arXiv.2411.07077): Carson, E. & Ma, Y. A stable one-synchronization variant of reorthogonalized block classical Gram--Schmidt. arXiv:2411.07077, 2024.  DOI: 10.48550/arXiv.2411.07077.
 * [Oktay 2024](https://dspace.cuni.cz/bitstream/handle/20.500.11956/191480/140119625.pdf?sequence=1): Ph.D. thesis. Faculty of Mathematics and Physics, Charles University, Prague, 2024.
 * [Oktay & Carson 2023](https://doi.org/10.1002/pamm.202200060): Okay, E. and Carson, E.  Using mixed precision in low-synchronization reorthogonalized block classical Gram-Schmidt. PAMM. Vol 23, 1, pp e202200060, 2023.  DOI: 10.1002/pamm.202200060
 
@@ -243,6 +245,7 @@ If you are using results from a specific paper, please cite the paper and the ve
 * [v1.2022.mp](https://github.com/katlund/BlockStab/releases/tag/v1.2022.mp): [Oktay & Carson 2023](https://doi.org/10.1002/pamm.202200060).
 * [v2.2024-beta](https://github.com/katlund/BlockStab/releases/tag/v2.2024-beta): [Oktay 2024](https://dspace.cuni.cz/bitstream/handle/20.500.11956/191480/140119625.pdf?sequence=1)
 * [v2.1.2024](https://github.com/katlund/BlockStab/releases/tag/v2.1.2024): [Carson, et al. 2024 A](https://arxiv.org/abs/2405.01298v2) and [Carson, et al. 2024 B](https://arxiv.org/abs/2408.10109)
+* [v2.2.2024](https://github.com/katlund/BlockStab/releases/tag/v2.2.2024): [Carson & Ma, 2024](https://doi.org/10.48550/arXiv.2411.07077)
 
 To cite this package in general, please use the following format:
 

--- a/main/BGS.m
+++ b/main/BGS.m
@@ -71,7 +71,7 @@ switch lower(skel)
         tic;
         [QQ, RR] = bcgs_iro(XX, s, musc, param);
         run_time = toc;
-
+        
 % [Stewart 2008] variant --------------------------------------------------
     case {'bcgs_sror'}
         tic;
@@ -194,6 +194,21 @@ switch lower(skel)
     case {'bcgs_pip_iro'}
         tic;
         [QQ, RR] = bcgs_pip_iro(XX, s, musc, param);
+        run_time = toc;
+
+    case {'bcgs_iro_p_1s'}
+        tic;
+        [QQ, RR] = bcgs_iro_p_1s(XX, s, musc, param);
+        run_time = toc;
+    
+    case {'bcgs_iro_p_2s'}
+        tic;
+        [QQ, RR] = bcgs_iro_p_2s(XX, s, musc, param);
+        run_time = toc;
+
+    case {'bcgs_iro_p_1s_2s'}
+        tic;
+        [QQ, RR] = bcgs_iro_p_1s_2s(XX, s, musc, param);
         run_time = toc;
 		
 % Mixed Precision variants ------------------------------------------------

--- a/main/skeletons/bcgs_iro_p_1s.m
+++ b/main/skeletons/bcgs_iro_p_1s.m
@@ -1,0 +1,109 @@
+function [QQ, RR] = bcgs_iro_p_1s(XX, s, musc, param)
+% [QQ, RR] = BCGS_IRO_P_1S(XX, s, musc, param) performs BCGS_IRO_P_1s with
+% HouseQR fixed for the first vector (_a).
+%
+% See BGS for more details about the parameters, and INTRAORTHO for musc
+% options.
+%
+% Part of the BlockStab package documented in [Carson, et al.
+% 2022](https://doi.org/10.1016/j.laa.2021.12.017).
+
+%%
+% Default: debugging off
+if nargin < 4
+    param.verbose = 0;
+end
+
+% Pre-allocate memory for QQ and RR
+[m, n] = size(XX);
+RR = zeros(n,n);
+QQ = zeros(m,n);
+p = n/s;
+
+% Set up block indices
+kk = 1:s;
+sk = s;
+s1 = kk;
+s2 = s1 + s;
+
+% Strong first step
+W = XX(:,kk);
+[QQ(:,kk), RR(kk,kk)] = qr(W, 0);
+
+if param.verbose
+    fprintf('         LOO      |    RelRes\n');
+    fprintf('-----------------------------------\n');
+    fprintf('%3.0d:', 1);
+    fprintf('  %2.4e  |',...
+        norm( eye(s) - InnerProd(QQ(:, 1:s), QQ(:, 1:s), musc) ) );
+    fprintf('  %2.4e\n',...
+        norm( XX(:,1:s) - QQ(:,1:s) * RR(1:s,1:s) ) / norm(XX(:,1:s)) );
+end
+
+% k.1.1
+tmp = InnerProd([QQ(:,1:sk), XX(:,kk+s)], XX(:,kk+s), musc);
+S_col = tmp(1:sk,:);
+omega = tmp(kk+s,:);
+Skk = chol_switch(omega - S_col'*S_col, param);
+
+% Update block indices
+kk = kk + s;
+sk = sk + s;
+
+% k.1.2
+W = XX(:,kk) - QQ(:,1:sk-s) * S_col;
+U = W / Skk;
+
+for k = 2:p-1
+    % k.2
+    tmp = InnerProd([QQ(:,1:sk-s) U XX(:,kk+s)], [U XX(:,kk+s)], musc);
+    Y_col = tmp(1:sk-s,s1);
+    Y_diag = chol_switch(tmp(kk,s1) - Y_col' * Y_col, param);
+    QQ(:,kk) = (U - QQ(:,1:sk-s) * Y_col ) / Y_diag;
+    
+    % k.3
+    RR(1:sk-s,kk) = S_col + Y_col*Skk;
+    RR(kk,kk) = Y_diag*Skk;
+    
+    if param.verbose
+        fprintf('%3.0d:', k);
+        fprintf('  %2.4e  |',...
+            norm( eye(sk) - InnerProd(QQ(:, 1:sk), QQ(:, 1:sk), musc) ) );
+        fprintf('  %2.4e\n',...
+            norm( XX(:,1:sk) - QQ(:,1:sk) * RR(1:sk,1:sk) ) / norm(XX(:,1:sk)) );
+    end
+
+    % (k+1).1.1
+    Z_col = tmp(1:sk-s,s2);
+    P = tmp(kk,s2);
+    S_col = [Z_col; Y_diag' \ (P - Y_col' * Z_col)];
+    
+
+    % Update block indices
+    kk = kk + s;
+    sk = sk + s;
+
+    % (k+1).1.2
+    Skk = chol_switch(tmp(kk,s2) - S_col'*S_col, param);
+    W = XX(:,kk) - QQ(:,1:sk-s) * S_col;
+    U = W/Skk;
+end
+
+% p.2
+tmp = InnerProd([QQ(:,1:sk-s) U], U, musc);
+Y_col = tmp(1:sk-s,s1);
+Y_diag = chol_switch(tmp(kk,s1) - Y_col' * Y_col, param);
+QQ(:,kk) = (U - QQ(:,1:sk-s) * Y_col ) / Y_diag;
+
+% p.3
+RR(1:sk-s,kk) = S_col + Y_col*Skk;
+RR(kk,kk) = Y_diag*Skk;
+
+if param.verbose
+    fprintf('%3.0d:', k);
+    fprintf('  %2.4e  |',...
+        norm( eye(sk) - InnerProd(QQ(:, 1:sk), QQ(:, 1:sk), musc) ) );
+    fprintf('  %2.4e\n',...
+        norm( XX(:,1:sk) - QQ(:,1:sk) * RR(1:sk,1:sk) ) / norm(XX(:,1:sk)) );
+end
+end

--- a/main/skeletons/bcgs_iro_p_1s.m
+++ b/main/skeletons/bcgs_iro_p_1s.m
@@ -1,12 +1,16 @@
 function [QQ, RR] = bcgs_iro_p_1s(XX, s, musc, param)
-% [QQ, RR] = BCGS_IRO_P_1S(XX, s, musc, param) performs BCGS_IRO_P_1s with
-% HouseQR fixed for the first vector (_a).
+% [QQ, RR] = BCGS_IRO_P_1S(XX, s, musc, param) performs Block Classical
+% Gram--Schmidt with one sync on the m x n matrix XX with p = n/s block
+% partitions each of size s.
+% HouseQR is fixed for the first vector (_a).
+%
+% See Algorithm 2 from [Carson & Ma, 2024] for details.
 %
 % See BGS for more details about the parameters, and INTRAORTHO for musc
 % options.
 %
-% Part of the BlockStab package documented in [Carson, et al.
-% 2022](https://doi.org/10.1016/j.laa.2021.12.017).
+% Part of [BlockStab](https://github.com/katlund) package.  Check README
+% for how to properly cite and reuse this file.
 
 %%
 % Default: debugging off

--- a/main/skeletons/bcgs_iro_p_1s_2s.m
+++ b/main/skeletons/bcgs_iro_p_1s_2s.m
@@ -1,0 +1,247 @@
+function [QQ, RR] = bcgs_iro_p_1s_2s(XX, s, musc, param)
+
+[QQ, RR, flag, sk] = bcgs_iro_p_1s_sub(XX, s, musc, param);
+
+if flag ~= 0
+    [QQ, RR] = bcgs_iro_p_2s_sub(XX, s, musc, param, QQ, RR, sk);
+end
+
+end
+
+function [QQ, RR, flag, sk] = bcgs_iro_p_1s_sub(XX, s, musc, param)
+% [QQ, RR] = BCGS_IRO_P_1S(XX, s, musc, param) performs BCGS_IRO_P_1s with
+% HouseQR fixed for the first vector (_a).
+%
+% See BGS for more details about the parameters, and INTRAORTHO for musc
+% options.
+%
+% Part of the BlockStab package documented in [Carson, et al.
+% 2022](https://doi.org/10.1016/j.laa.2021.12.017).
+
+%%
+% Default: debugging off
+if nargin < 4
+    param.verbose = 0;
+end
+
+% Pre-allocate memory for QQ and RR
+[m, n] = size(XX);
+RR = zeros(n,n);
+QQ = zeros(m,n);
+p = n/s;
+flag = 0;
+
+% Set up block indices
+kk = 1:s;
+sk = s;
+s1 = kk;
+s2 = s1 + s;
+
+% Strong first step
+W = XX(:,kk);
+normX = norm(W, 'fro');
+[QQ(:,kk), RR(kk,kk)] = qr(W, 0);
+
+if param.verbose
+    fprintf('         LOO      |    RelRes\n');
+    fprintf('-----------------------------------\n');
+    fprintf('%3.0d:', 1);
+    fprintf('  %2.4e  |',...
+        norm( eye(s) - InnerProd(QQ(:, 1:s), QQ(:, 1:s), musc) ) );
+    fprintf('  %2.4e\n',...
+        norm( XX(:,1:s) - QQ(:,1:s) * RR(1:s,1:s) ) / norm(XX(:,1:s)) );
+end
+
+% k.1.1
+tmp = InnerProd([QQ(:,1:sk), XX(:,kk+s)], XX(:,kk+s), musc);
+S_col = tmp(1:sk,:);
+omega = tmp(kk+s,:);
+[Skk, nanflag] = chol_switch(omega - S_col'*S_col, param);
+if nanflag ~= 0
+    flag = 4;
+    sk = sk-s;
+    return
+end
+
+% Update block indices
+kk = kk + s;
+sk = sk + s;
+
+% k.1.2
+W = XX(:,kk) - QQ(:,1:sk-s) * S_col;
+U = W / Skk;
+
+for k = 2:p-1
+    % k.2
+    tmp = InnerProd([QQ(:,1:sk-s) U XX(:,kk+s)], [U XX(:,kk+s)], musc);
+    normX = sqrt(normX^2 + norm(XX(:,kk+s), 'fro')^2);
+    Y_col = tmp(1:sk-s,s1);
+    
+    eigvU2 = eig((tmp(kk,s1)+tmp(kk,s1)')/2.0);
+    if 3*min(abs(eigvU2)) <= max(abs(eigvU2)) 
+        flag = 1;
+        sk = sk - s;
+        return
+    end
+    [Y_diag, nanflag] = chol_switch(tmp(kk,s1) - Y_col' * Y_col, param);
+    if nanflag ~= 0
+        flag = 3;
+        sk = sk-s;
+        return
+    end
+    QQ(:,kk) = (U - QQ(:,1:sk-s) * Y_col ) / Y_diag;
+    
+    % k.3
+    RR(1:sk-s,kk) = S_col + Y_col*Skk;
+    RR(kk,kk) = Y_diag*Skk;
+    
+    if param.verbose
+        fprintf('%3.0d:', k);
+        fprintf('  %2.4e  |',...
+            norm( eye(sk) - InnerProd(QQ(:, 1:sk), QQ(:, 1:sk), musc) ) );
+        fprintf('  %2.4e\n',...
+            norm( XX(:,1:sk) - QQ(:,1:sk) * RR(1:sk,1:sk) ) / norm(XX(:,1:sk)) );
+    end
+
+    % (k+1).1.1
+    Z_col = tmp(1:sk-s,s2);
+    P = tmp(kk,s2);
+    S_col = [Z_col; Y_diag' \ (P - Y_col' * Z_col)];
+    
+
+    % Update block indices
+    kk = kk + s;
+    sk = sk + s;
+
+    % (k+1).1.2
+    [Skk, nanflag] = chol_switch(tmp(kk,s2) - S_col'*S_col, param);
+    if nanflag ~= 0
+        flag = 2;
+        sk = sk-s;
+        return
+    end
+
+    W = XX(:,kk) - QQ(:,1:sk-s) * S_col;
+    U = W/Skk;
+    
+end
+
+% p.2
+tmp = InnerProd([QQ(:,1:sk-s) U], U, musc);
+Y_col = tmp(1:sk-s,s1);
+Y_diag = chol_switch(tmp(kk,s1) - Y_col' * Y_col, param);
+QQ(:,kk) = (U - QQ(:,1:sk-s) * Y_col ) / Y_diag;
+
+% p.3
+RR(1:sk-s,kk) = S_col + Y_col*Skk;
+RR(kk,kk) = Y_diag*Skk;
+
+if param.verbose
+    fprintf('%3.0d:', k);
+    fprintf('  %2.4e  |',...
+        norm( eye(sk) - InnerProd(QQ(:, 1:sk), QQ(:, 1:sk), musc) ) );
+    fprintf('  %2.4e\n',...
+        norm( XX(:,1:sk) - QQ(:,1:sk) * RR(1:sk,1:sk) ) / norm(XX(:,1:sk)) );
+end
+end
+
+
+function [QQ, RR] = bcgs_iro_p_2s_sub(XX, s, musc, param, QQ, RR, sk)
+% [QQ, RR] = BCGS_IRO_P_2S(XX, s, musc, param) performs BCGS_IRO_P_2s with
+% HouseQR fixed for the first vector (_a).
+%
+% See BGS for more details about the parameters, and INTRAORTHO for musc
+% options.
+%
+% Part of the BlockStab package documented in [Carson, et al.
+% 2022](https://doi.org/10.1016/j.laa.2021.12.017).
+
+%%
+% Default: debugging off
+if nargin < 4
+    param.verbose = 0;
+end
+
+% Pre-allocate memory for QQ and RR
+[m, n] = size(XX);
+p = (n-sk+1)/s;
+
+% Set up block indices
+kk = sk-s+1:sk;
+s1 = 1:s;
+s2 = s1 + s;
+
+
+if param.verbose
+    fprintf('         LOO      |    RelRes\n');
+    fprintf('-----------------------------------\n');
+    fprintf('%3.0d:', 1);
+    fprintf('  %2.4e  |',...
+        norm( eye(s) - InnerProd(QQ(:, 1:s), QQ(:, 1:s), musc) ) );
+    fprintf('  %2.4e\n',...
+        norm( XX(:,1:s) - QQ(:,1:s) * RR(1:s,1:s) ) / norm(XX(:,1:s)) );
+end
+
+% k.1.1
+S_col = InnerProd(QQ(:,1:sk), XX(:,kk+s), musc);
+
+% Update block indices
+kk = kk + s;
+sk = sk + s;
+
+% % k.1.2
+W = XX(:,kk) - QQ(:,1:sk-s) * S_col;
+[U, Skk] = IntraOrtho(W, musc, param);
+
+for k = 2:p
+    % k.2
+    tmp = InnerProd([QQ(:,1:sk-s) U], [U XX(:,kk+s)], musc);
+    Y_col = tmp(1:sk-s,s1);
+    Y_diag = chol_switch(tmp(kk,s1) - Y_col' * Y_col, param);
+    QQ(:,kk) = (U - QQ(:,1:sk-s) * Y_col ) / Y_diag;
+    
+    % k.3
+    RR(1:sk-s,kk) = S_col + Y_col*Skk;
+    RR(kk,kk) = Y_diag*Skk;
+    
+    if param.verbose
+        fprintf('%3.0d:', k);
+        fprintf('  %2.4e  |',...
+            norm( eye(sk) - InnerProd(QQ(:, 1:sk), QQ(:, 1:sk), musc) ) );
+        fprintf('  %2.4e\n',...
+            norm( XX(:,1:sk) - QQ(:,1:sk) * RR(1:sk,1:sk) ) / norm(XX(:,1:sk)) );
+    end
+
+    % (k+1).1.1
+    Z_col = tmp(1:sk-s,s2);
+    P = tmp(kk,s2);
+    S_col = [Z_col; Y_diag' \ (P - Y_col' * Z_col)];
+    
+
+    % Update block indices
+    kk = kk + s;
+    sk = sk + s;
+
+    % (k+1).1.2
+    W = XX(:,kk) - QQ(:,1:sk-s) * S_col;
+    [U, Skk] = IntraOrtho(W, musc, param);
+end
+
+% p.2
+tmp = InnerProd([QQ(:,1:sk-s) U], U, musc);
+Y_col = tmp(1:sk-s,s1);
+Y_diag = chol_switch(tmp(kk,s1) - Y_col' * Y_col, param);
+QQ(:,kk) = (U - QQ(:,1:sk-s) * Y_col ) / Y_diag;
+
+% p.3
+RR(1:sk-s,kk) = S_col + Y_col*Skk;
+RR(kk,kk) = Y_diag*Skk;
+
+if param.verbose
+    fprintf('%3.0d:', k);
+    fprintf('  %2.4e  |',...
+        norm( eye(sk) - InnerProd(QQ(:, 1:sk), QQ(:, 1:sk), musc) ) );
+    fprintf('  %2.4e\n',...
+        norm( XX(:,1:sk) - QQ(:,1:sk) * RR(1:sk,1:sk) ) / norm(XX(:,1:sk)) );
+end
+end

--- a/main/skeletons/bcgs_iro_p_1s_2s.m
+++ b/main/skeletons/bcgs_iro_p_1s_2s.m
@@ -1,4 +1,19 @@
 function [QQ, RR] = bcgs_iro_p_1s_2s(XX, s, musc, param)
+% [QQ, RR] = BCGS_IRO_P_1S_2S(XX, s, musc, param) performs Block Classical
+% Gram--Schmidt on the m x n matrix XX with p = n/s block partitions each
+% of size s with intra-orthogonalization procedure determined by musc.
+% This subroutine combines BCGS_IRO_P_1S and BCGS_IRO_P_2S to reduce sync 
+% points as much as possible.
+% HouseQR is fixed for the first vector (_a).
+%
+% See Algorithm 4 from [Carson & Ma, 2024] for details.
+%
+% See BGS for more details about the parameters, and INTRAORTHO for musc
+% options.
+%
+% Part of [BlockStab](https://github.com/katlund) package.  Check README
+% for how to properly cite and reuse this file.
+
 
 [QQ, RR, flag, sk] = bcgs_iro_p_1s_sub(XX, s, musc, param);
 
@@ -9,14 +24,12 @@ end
 end
 
 function [QQ, RR, flag, sk] = bcgs_iro_p_1s_sub(XX, s, musc, param)
-% [QQ, RR] = BCGS_IRO_P_1S(XX, s, musc, param) performs BCGS_IRO_P_1s with
-% HouseQR fixed for the first vector (_a).
-%
-% See BGS for more details about the parameters, and INTRAORTHO for musc
-% options.
-%
-% Part of the BlockStab package documented in [Carson, et al.
-% 2022](https://doi.org/10.1016/j.laa.2021.12.017).
+% [QQ, RR] = BCGS_IRO_P_1S_sub(XX, s, musc, param) performs Block Classical
+% Gram--Schmidt with one sync on the m x n matrix XX with p = n/s block
+% partitions each of size s.
+% This subroutine is similar to BCGS_IRO_P_1S, but employs additional
+% condition to determine when to switch to BCGS_IRO_P_2S iterations
+% adaptively.
 
 %%
 % Default: debugging off
@@ -147,14 +160,12 @@ end
 
 
 function [QQ, RR] = bcgs_iro_p_2s_sub(XX, s, musc, param, QQ, RR, sk)
-% [QQ, RR] = BCGS_IRO_P_2S(XX, s, musc, param) performs BCGS_IRO_P_2s with
-% HouseQR fixed for the first vector (_a).
-%
-% See BGS for more details about the parameters, and INTRAORTHO for musc
-% options.
-%
-% Part of the BlockStab package documented in [Carson, et al.
-% 2022](https://doi.org/10.1016/j.laa.2021.12.017).
+% [QQ, RR] = BCGS_IRO_P_2S_sub(XX, s, musc, param) performs Block Classical
+% Gram--Schmidt with one sync on the matrix XX(:, sk-s+1:n) with
+% p = (n-sk+1)/s block partitions each of size s.
+% This subroutine is similar to BCGS_IRO_P_2S, but only orthogonalizes
+% XX(:, sk-s+1:n). The first sk-s columns has been handled by
+% BCGS_IRO_P_1S_sub.
 
 %%
 % Default: debugging off

--- a/main/skeletons/bcgs_iro_p_2s.m
+++ b/main/skeletons/bcgs_iro_p_2s.m
@@ -1,0 +1,105 @@
+function [QQ, RR] = bcgs_iro_p_2s(XX, s, musc, param)
+% [QQ, RR] = BCGS_IRO_P_2S(XX, s, musc, param) performs BCGS_IRO_P_2s with
+% HouseQR fixed for the first vector (_a).
+%
+% See BGS for more details about the parameters, and INTRAORTHO for musc
+% options.
+%
+% Part of the BlockStab package documented in [Carson, et al.
+% 2022](https://doi.org/10.1016/j.laa.2021.12.017).
+
+%%
+% Default: debugging off
+if nargin < 4
+    param.verbose = 0;
+end
+
+% Pre-allocate memory for QQ and RR
+[m, n] = size(XX);
+RR = zeros(n,n);
+QQ = zeros(m,n);
+p = n/s;
+
+% Set up block indices
+kk = 1:s;
+sk = s;
+s1 = kk;
+s2 = s1 + s;
+
+% Strong first step
+W = XX(:,kk);
+[QQ(:,kk), RR(kk,kk)] = qr(W, 0);
+
+if param.verbose
+    fprintf('         LOO      |    RelRes\n');
+    fprintf('-----------------------------------\n');
+    fprintf('%3.0d:', 1);
+    fprintf('  %2.4e  |',...
+        norm( eye(s) - InnerProd(QQ(:, 1:s), QQ(:, 1:s), musc) ) );
+    fprintf('  %2.4e\n',...
+        norm( XX(:,1:s) - QQ(:,1:s) * RR(1:s,1:s) ) / norm(XX(:,1:s)) );
+end
+
+% k.1.1
+S_col = InnerProd(QQ(:,1:sk), XX(:,kk+s), musc);
+
+% Update block indices
+kk = kk + s;
+sk = sk + s;
+
+% % k.1.2
+W = XX(:,kk) - QQ(:,1:sk-s) * S_col;
+[U, Skk] = IntraOrtho(W, musc, param);
+
+for k = 2:p-1
+    % k.2
+    tmp = InnerProd([QQ(:,1:sk-s) U], [U XX(:,kk+s)], musc);
+    Y_col = tmp(1:sk-s,s1);
+    Y_diag = chol_switch(tmp(kk,s1) - Y_col' * Y_col, param);
+    QQ(:,kk) = (U - QQ(:,1:sk-s) * Y_col ) / Y_diag;
+    
+    % k.3
+    RR(1:sk-s,kk) = S_col + Y_col*Skk;
+    RR(kk,kk) = Y_diag*Skk;
+    
+    if param.verbose
+        fprintf('%3.0d:', k);
+        fprintf('  %2.4e  |',...
+            norm( eye(sk) - InnerProd(QQ(:, 1:sk), QQ(:, 1:sk), musc) ) );
+        fprintf('  %2.4e\n',...
+            norm( XX(:,1:sk) - QQ(:,1:sk) * RR(1:sk,1:sk) ) / norm(XX(:,1:sk)) );
+    end
+
+    % (k+1).1.1
+    Z_col = tmp(1:sk-s,s2);
+    P = tmp(kk,s2);
+    S_col = [Z_col; Y_diag' \ (P - Y_col' * Z_col)];
+    
+
+    % Update block indices
+    kk = kk + s;
+    sk = sk + s;
+
+    % (k+1).1.2
+    W = XX(:,kk) - QQ(:,1:sk-s) * S_col;
+    [U, Skk] = IntraOrtho(W, musc, param);
+end
+
+% p.2
+tmp = InnerProd([QQ(:,1:sk-s) U], U, musc);
+Y_col = tmp(1:sk-s,s1);
+Y_diag = chol_switch(tmp(kk,s1) - Y_col' * Y_col, param);
+QQ(:,kk) = (U - QQ(:,1:sk-s) * Y_col ) / Y_diag;
+
+% p.3
+RR(1:sk-s,kk) = S_col + Y_col*Skk;
+RR(kk,kk) = Y_diag*Skk;
+
+if param.verbose
+    fprintf('%3.0d:', k);
+    fprintf('  %2.4e  |',...
+        norm( eye(sk) - InnerProd(QQ(:, 1:sk), QQ(:, 1:sk), musc) ) );
+    fprintf('  %2.4e\n',...
+        norm( XX(:,1:sk) - QQ(:,1:sk) * RR(1:sk,1:sk) ) / norm(XX(:,1:sk)) );
+end
+end

--- a/main/skeletons/bcgs_iro_p_2s.m
+++ b/main/skeletons/bcgs_iro_p_2s.m
@@ -1,12 +1,17 @@
 function [QQ, RR] = bcgs_iro_p_2s(XX, s, musc, param)
-% [QQ, RR] = BCGS_IRO_P_2S(XX, s, musc, param) performs BCGS_IRO_P_2s with
-% HouseQR fixed for the first vector (_a).
+% [QQ, RR] = BCGS_IRO_P_2S(XX, s, musc, param) performs Block Classical
+% Gram--Schmidt with two sync on the m x n matrix XX with p = n/s block
+% partitions each of size s with intra-orthogonalization procedure
+% determined by musc.
+% HouseQR is fixed for the first vector (_a).
+%
+% See Algorithm 3 from [Carson & Ma, 2024] for details.
 %
 % See BGS for more details about the parameters, and INTRAORTHO for musc
 % options.
 %
-% Part of the BlockStab package documented in [Carson, et al.
-% 2022](https://doi.org/10.1016/j.laa.2021.12.017).
+% Part of [BlockStab](https://github.com/katlund) package.  Check README
+% for how to properly cite and reuse this file.
 
 %%
 % Default: debugging off

--- a/tests/configs/bcgs_pip_iro_1s.json
+++ b/tests/configs/bcgs_pip_iro_1s.json
@@ -1,0 +1,20 @@
+{
+  "bcgs_pip_iro": {
+    "houseqr": []
+  },
+  "bcgs_iro_p_1s_2s": {
+    "houseqr": []
+  },
+  "bcgs_iro_a": {
+    "houseqr": []
+  },
+  "bcgs_iro_p_2s": {
+    "houseqr": []
+  },
+  "bcgs_iro_p_1s": {
+    "houseqr": []
+  },
+  "bcgs_iro_a_1s": {
+    "houseqr": []
+  }
+}

--- a/tests/test_bcgs_pip_reortho_1s.m
+++ b/tests/test_bcgs_pip_reortho_1s.m
@@ -1,0 +1,62 @@
+% This is a script to reproduce plots in stable one-sync reortho BCGS paper.
+% Note that more tests are run than are presented in the paper.
+%
+% Algorithm configurations should be indexed as follows:
+% (1) BCGS-PIPI+(HouseQR)
+% (2) BCGSI+P-1s2s(HouseQR)
+% (3) BCGSI+A(HouseQR)
+% (4) BCGSI+P-2s(HouseQR)
+% (5) BCGSI+P-1s(HouseQR)
+% (6) BCGSI+A-1s(HouseQR)
+%
+% Part of [BlockStab](https://github.com/katlund) package.  Check README
+% for how to properly cite and reuse this file.
+
+%% SET UP
+% Specify algorithm configuration file
+config_file = 'bcgs_pip_iro_1s.json';
+
+% Set up options struct to be reused by GEN_PLOTS
+options = [];
+options.save_eps = true;
+options.save_pdf = true;
+options.save_fig = false;
+
+%% Kappa plots
+% Default kappa plot
+mat_type = 'default';
+options_default.num_rows = 100;
+options_default.num_partitions = 10;
+options_default.block_size = 2;
+run_data_default = RunKappaPlot(mat_type, options_default, config_file);
+run_data_default.options = options;
+close all;
+
+% Glued kappa plot
+mat_type = 'glued';
+options_glued.num_rows = 100;
+options_glued.num_partitions = 10;
+options_glued.block_size = 2;
+options_glued.scale = 1:12;
+run_data_glued = RunKappaPlot(mat_type, options_glued, config_file);
+run_data_glued.options = options;
+close all;
+
+% Monomial kappa plot
+mat_type = 'monomial';
+options_monomial.num_rows = 2000;
+options_monomial.num_partitions = 120;
+options_monomial.block_size = 10;
+run_data_monomial = RunKappaPlot(mat_type, options_monomial, config_file);
+run_data_monomial.options = options;
+close all;
+
+% Piled kappa plot
+mat_type = 'piled';
+options_piled.num_rows = 100;
+options_piled.num_partitions = 10;
+options_piled.block_size = 5;
+run_data_piled = RunKappaPlot(mat_type, options_piled, config_file);
+run_data_piled.options = options;
+close all;
+


### PR DESCRIPTION
In the main file, I added bcgs_iro_p_1s.m, bcgs_iro_p_2s.m, and bcgs_iro_p_1s_2s.m.
bcgs_iro_p_1s.m: one-sync per iteration, O(eps) LOO under the assumption O(eps) kappa(X)^2 <= 1.
bcgs_iro_p_2s.m: two-sync per iteration, O(eps) LOO under the assumption O(eps) kappa(X) <= 1.
bcgs_iro_p_1s_2s.m: around 1.5-sync per iteration (mainly for s-step GMRES), O(eps) LOO under the assumption O(eps) kappa(X) <= 1.

In the test file, I added test_bcgs_pip_reortho_1s.m for testing these three new methods.